### PR TITLE
Fix xraylarch's `Interpreter` API

### DIFF
--- a/xas/xasproject.py
+++ b/xas/xasproject.py
@@ -11,7 +11,7 @@ import pickle
 class XASDataSet:
     _md = {}
     _filename = ''
-    _larch = Interpreter(with_plugins=False)
+    _larch = Interpreter()
 
     def __init__(self, name=None, md=None, energy = None, mu=None,
                  filename=None, datatype=None, process=True,


### PR DESCRIPTION
The plugins were removed from `xraylarch` [v0.9.59](https://github.com/xraypy/xraylarch/releases/tag/0.9.59). The deployed version is v0.9.60 in the [2023-1.0 conda envs](https://zenodo.org/record/7470912).